### PR TITLE
security(dashboard): enforce token auth for dashboard API and SSE

### DIFF
--- a/src/cli/commands/dashboard.ts
+++ b/src/cli/commands/dashboard.ts
@@ -9,6 +9,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomBytes } from 'crypto';
 import chalk from 'chalk';
 import { findAvailablePort } from '../../utils/docs-preview/server-manager.js';
 import type { DashboardLockFile } from '../../dashboard/types.js';
@@ -39,11 +40,22 @@ export async function dashboardCommand(options: DashboardOptions = {}): Promise<
 
     // Register project via API
     try {
-      await fetch(`http://localhost:${existing.port}/api/projects`, {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (existing.authToken) {
+        headers['X-Specweave-Dashboard-Token'] = existing.authToken;
+      }
+
+      const registerResponse = await fetch(`http://localhost:${existing.port}/api/projects`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ path: projectRoot }),
       });
+
+      if (!registerResponse.ok) {
+        throw new Error(`Failed to register project (HTTP ${registerResponse.status})`);
+      }
     } catch {
       // Server might not be responding — fall through to start new one
       console.log(chalk.yellow('Existing dashboard not responding. Starting new instance...'));
@@ -71,11 +83,13 @@ export async function dashboardCommand(options: DashboardOptions = {}): Promise<
 async function startNewDashboard(projectRoot: string, options: DashboardOptions): Promise<void> {
   const requestedPort = options.port ? parseInt(options.port, 10) : 3456;
   const port = await findAvailablePort(requestedPort, requestedPort + 20);
+  const authToken = randomBytes(32).toString('hex');
 
   const { DashboardServer } = await import('../../dashboard/server/dashboard-server.js');
 
   const server = new DashboardServer({
     port,
+    authToken,
     projectRoots: [projectRoot],
     openBrowser: options.browser !== false,
   });
@@ -83,7 +97,13 @@ async function startNewDashboard(projectRoot: string, options: DashboardOptions)
   const instance = await server.start();
 
   // Write lock file
-  writeLockFile({ port, pid: process.pid, startedAt: new Date().toISOString(), projects: [projectRoot] });
+  writeLockFile({
+    port,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    projects: [projectRoot],
+    authToken,
+  });
 
   const projectSlug = pathToSlug(projectRoot);
   const url = `${instance.url}/?project=${projectSlug}`;

--- a/src/dashboard/client/src/contexts/SSEContext.tsx
+++ b/src/dashboard/client/src/contexts/SSEContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useRef, useCallback, useState } from 'react';
 import type { ReactNode } from 'react';
+import { appendDashboardToken } from '../utils/dashboardAuth';
 
 export type SSEStatus = 'connecting' | 'connected' | 'disconnected';
 
@@ -33,7 +34,7 @@ export function SSEProvider({ url = '/api/events', children }: { url?: string; c
     }
 
     setStatus('connecting');
-    const es = new EventSource(url);
+    const es = new EventSource(appendDashboardToken(url));
     eventSourceRef.current = es;
 
     for (const type of EVENT_TYPES) {

--- a/src/dashboard/client/src/main.tsx
+++ b/src/dashboard/client/src/main.tsx
@@ -3,6 +3,19 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles/globals.css';
+import { getDashboardToken } from './utils/dashboardAuth';
+
+const originalFetch = window.fetch.bind(window);
+window.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const token = getDashboardToken();
+  if (!token) {
+    return originalFetch(input, init);
+  }
+
+  const headers = new Headers(init?.headers || {});
+  headers.set('X-Specweave-Dashboard-Token', token);
+  return originalFetch(input, { ...init, headers });
+}) as typeof window.fetch;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/dashboard/client/src/utils/dashboardAuth.ts
+++ b/src/dashboard/client/src/utils/dashboardAuth.ts
@@ -1,0 +1,26 @@
+declare global {
+  interface Window {
+    __SPECWEAVE_DASHBOARD_TOKEN__?: string;
+  }
+}
+
+/** Read dashboard auth token injected by the server into index.html. */
+export function getDashboardToken(): string | null {
+  const token = window.__SPECWEAVE_DASHBOARD_TOKEN__;
+  if (typeof token !== 'string' || token.length === 0) {
+    return null;
+  }
+  return token;
+}
+
+/** Append dashboard auth token as query param (used for EventSource). */
+export function appendDashboardToken(url: string): string {
+  const token = getDashboardToken();
+  if (!token) {
+    return url;
+  }
+
+  const parsed = new URL(url, window.location.origin);
+  parsed.searchParams.set('token', token);
+  return parsed.pathname + parsed.search + parsed.hash;
+}

--- a/src/dashboard/server/dashboard-server.ts
+++ b/src/dashboard/server/dashboard-server.ts
@@ -2,6 +2,7 @@ import * as http from 'http';
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
+import { timingSafeEqual } from 'crypto';
 import { fileURLToPath } from 'url';
 import { Router, sendJson, readBody } from './router.js';
 import { SSEManager } from './sse-manager.js';
@@ -21,6 +22,8 @@ const __dirname = path.dirname(__filename);
 
 export interface DashboardServerOptions {
   port: number;
+  host?: string;
+  authToken?: string;
   projectRoots: string[];
   openBrowser: boolean;
 }
@@ -47,6 +50,8 @@ export class DashboardServer {
   private server: http.Server | null = null;
   private router: Router;
   private sseManager: SSEManager;
+  private readonly host: string;
+  private readonly authToken: string;
   private projects = new Map<string, {
     root: string;
     watcher: FileWatcher;
@@ -61,6 +66,8 @@ export class DashboardServer {
   }>();
 
   constructor(private options: DashboardServerOptions) {
+    this.host = options.host || '';
+    this.authToken = options.authToken || '';
     this.sseManager = new SSEManager();
     this.router = new Router();
 
@@ -152,14 +159,21 @@ export class DashboardServer {
         reject(err);
       });
 
-      this.server.listen(this.options.port, () => {
-        const url = `http://localhost:${this.options.port}`;
+      const onListen = () => {
+        const displayHost = this.host || 'localhost';
+        const url = `http://${displayHost}:${this.options.port}`;
         resolve({
           url,
           port: this.options.port,
           stop: () => this.stop(),
         });
-      });
+      };
+
+      if (this.host) {
+        this.server.listen(this.options.port, this.host, onListen);
+      } else {
+        this.server.listen(this.options.port, onListen);
+      }
     });
   }
 
@@ -189,7 +203,7 @@ export class DashboardServer {
       const origin = req.headers.origin || '';
       const headers: Record<string, string> = {
         'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Headers': 'Content-Type, X-Specweave-Dashboard-Token',
         'Vary': 'Origin',
       };
       if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
@@ -197,6 +211,12 @@ export class DashboardServer {
       }
       res.writeHead(204, headers);
       res.end();
+      return;
+    }
+
+    // Security: Require dashboard token for API and SSE access.
+    if ((url.startsWith('/api/events') || url.startsWith('/api/')) && !this.isRequestAuthorized(req)) {
+      sendJson(res, { ok: false, error: 'Unauthorized' }, 401);
       return;
     }
 
@@ -217,6 +237,34 @@ export class DashboardServer {
 
     // Static files
     await this.serveStaticFile(req, res, url);
+  }
+
+  /** Verify API requests include the dashboard session token. */
+  private isRequestAuthorized(req: http.IncomingMessage): boolean {
+    if (!this.authToken) {
+      return true;
+    }
+
+    const header = req.headers['x-specweave-dashboard-token'];
+    const headerToken = Array.isArray(header) ? (header[0] || '') : (header || '');
+    const requestUrl = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+    const queryToken = requestUrl.searchParams.get('token') || '';
+
+    return this.constantTimeTokenEquals(headerToken) || this.constantTimeTokenEquals(queryToken);
+  }
+
+  /** Constant-time token comparison to avoid token oracle leaks. */
+  private constantTimeTokenEquals(candidate: string): boolean {
+    if (!candidate || !this.authToken) {
+      return false;
+    }
+
+    const candidateBuf = Buffer.from(candidate);
+    const tokenBuf = Buffer.from(this.authToken);
+    if (candidateBuf.length !== tokenBuf.length) {
+      return false;
+    }
+    return timingSafeEqual(candidateBuf, tokenBuf);
   }
 
   /** Resolve project from query string ?project=<id> */
@@ -951,10 +999,34 @@ export class DashboardServer {
     const ext = path.extname(filePath);
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
+    // Inject dashboard auth token into the SPA bootstrap page.
+    if (ext === '.html' && path.basename(filePath) === 'index.html') {
+      try {
+        const html = fs.readFileSync(filePath, 'utf-8');
+        const tokenBootstrap = `<script>window.__SPECWEAVE_DASHBOARD_TOKEN__=${JSON.stringify(this.authToken)};</script>`;
+        const content = html.includes('</head>')
+          ? html.replace('</head>', `${tokenBootstrap}</head>`)
+          : `${tokenBootstrap}${html}`;
+        res.writeHead(200, {
+          'Content-Type': contentType,
+          'Cache-Control': 'no-cache',
+        });
+        res.end(content);
+        return;
+      } catch {
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+        }
+        res.end('Internal server error');
+        return;
+      }
+    }
+
     res.writeHead(200, {
       'Content-Type': contentType,
       'Cache-Control': ext === '.html' ? 'no-cache' : 'public, max-age=31536000, immutable',
     });
+
     const stream = fs.createReadStream(filePath);
     stream.on('error', () => {
       if (!res.headersSent) {

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -243,6 +243,7 @@ export interface DashboardLockFile {
   pid: number;
   startedAt: string;
   projects: string[];  // Array of project paths
+  authToken?: string;  // Dashboard API auth token
 }
 
 // API response wrapper

--- a/tests/unit/dashboard/dashboard-auth.test.ts
+++ b/tests/unit/dashboard/dashboard-auth.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit Test: Dashboard API Authentication
+ *
+ * Verifies token-based protection for dashboard API and SSE endpoints.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as http from 'http';
+import { DashboardServer } from '../../../src/dashboard/server/dashboard-server.js';
+
+describe('Dashboard API Auth', () => {
+  const authToken = 'test-dashboard-token';
+  let tempDir: string;
+  let server: { url: string; port: number; stop: () => Promise<void> };
+
+  async function requestJson(
+    route: string,
+    options: { method?: string; headers?: Record<string, string> } = {}
+  ): Promise<{ status: number; body: any }> {
+    return new Promise((resolve, reject) => {
+      const url = new URL(route, server.url);
+      const req = http.request(
+        url,
+        {
+          method: options.method || 'GET',
+          headers: options.headers || {},
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            const raw = Buffer.concat(chunks).toString();
+            try {
+              resolve({ status: res.statusCode || 0, body: JSON.parse(raw) });
+            } catch {
+              resolve({ status: res.statusCode || 0, body: raw });
+            }
+          });
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  async function requestSseStatus(route: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const url = new URL(route, server.url);
+      const req = http.request(url, { method: 'GET' }, (res) => {
+        const status = res.statusCode || 0;
+        // SSE keeps the connection open; close after status is known.
+        res.destroy();
+        resolve(status);
+      });
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  beforeAll(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-auth-test-'));
+    fs.mkdirSync(path.join(tempDir, '.specweave'), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, '.specweave', 'state'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, '.specweave', 'config.json'),
+      JSON.stringify({ project: { name: 'dashboard-auth-test' } }, null, 2),
+    );
+
+    const dashServer = new DashboardServer({
+      port: 30000 + Math.floor(Math.random() * 30000),
+      projectRoots: [tempDir],
+      openBrowser: false,
+      authToken,
+    });
+    server = await dashServer.start();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server.stop();
+    }
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 401 when token is missing', async () => {
+    const { status, body } = await requestJson('/api/health');
+    expect(status).toBe(401);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    const { status, body } = await requestJson('/api/health', {
+      headers: { 'X-Specweave-Dashboard-Token': 'wrong-token' },
+    });
+    expect(status).toBe(401);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 200 when token is valid', async () => {
+    const { status, body } = await requestJson('/api/health', {
+      headers: { 'X-Specweave-Dashboard-Token': authToken },
+    });
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+
+  it('accepts token via SSE query parameter', async () => {
+    const status = await requestSseStatus(`/api/events?token=${encodeURIComponent(authToken)}`);
+    expect(status).toBe(200);
+  });
+
+  it('rejects SSE endpoint without token', async () => {
+    const status = await requestSseStatus('/api/events');
+    expect(status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add a per-session dashboard auth token generated by the dashboard CLI
- require the token for all `/api/*` and `/api/events` requests
- keep dashboard bind behavior unchanged (no forced localhost bind)
- inject the token into `index.html` at runtime and automatically attach it from the dashboard client
- persist the token in the dashboard lock file so additional `specweave dashboard` invocations can register projects securely

## Security impact
This closes the unauthenticated dashboard control surface (command execution, config updates, sync verify, marketplace actions) by requiring a valid session token.

## Validation
- `npx tsc --noEmit`
- `npm run build:dashboard`
- `npx vitest run tests/unit/dashboard/dashboard-auth.test.ts tests/unit/dashboard/marketplace-routes.test.ts`

## Notes
- Did not enforce local-only binding per request; auth hardening is applied regardless of bind interface.
