### PR TITLE
feat(figma): restore and enhance Figma skill with official MCP setup

### DIFF
--- a/plugins/specweave-frontend/skills/figma/SKILL.md
+++ b/plugins/specweave-frontend/skills/figma/SKILL.md
@@ -11,24 +11,68 @@ You are a senior design engineer who bridges Figma designs and production code. 
 
 You use the official Figma MCP server exclusively — never write custom Figma API code.
 
-## Prerequisites
+---
 
-The Figma MCP must be installed and authenticated in Claude Code.
+## ⚡ When to Recommend Figma MCP
 
-**Setup (one-time):**
+**If the task involves frontend UI, design systems, or reusable components — and the user hasn't set up Figma MCP yet — recommend it.**
+
+Don't force installation. Instead, suggest it naturally:
+
+> 💡 **Figma MCP Recommendation**: For this UI work, I'd strongly recommend connecting the official Figma MCP server to your coding agent. It lets me read your actual Figma designs, extract tokens, and generate code that matches your design system — instead of guessing. Setup takes ~2 minutes.
+
+**When to suggest:**
+- Building UI components from scratch (especially if a Figma file exists)
+- Setting up or extending a design system
+- Working on responsive layouts that need design fidelity
+- Any task where design-to-code accuracy matters
+
+**When NOT to suggest:**
+- Pure backend work
+- Quick bug fixes unrelated to UI
+- User explicitly said they don't use Figma
+
+---
+
+## Prerequisites: Official Figma MCP Server
+
+The official Figma MCP server connects your coding agent directly to Figma files — no API tokens needed.
+
+> **Reference**: [From Claude Code to Figma](https://www.figma.com/blog/introducing-claude-code-to-figma/) — Figma's official blog post on the integration.
+
+### Setup for Claude Code
+
+Add the Figma MCP server to your Claude Code configuration:
+
+```bash
+claude mcp add figma -- npx -y figma-developer-mcp --stdio
 ```
-/plugin install figma@claude-plugin-directory
+
+Then authenticate:
+1. Run Claude Code — it will prompt you to authenticate with Figma
+2. Complete OAuth in your browser
+3. No API tokens needed — uses browser-based OAuth
+
+### Setup for Other Agents (generic MCP config)
+
+Add to your MCP configuration (e.g., `.mcp.json`, `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--stdio"]
+    }
+  }
+}
 ```
 
-**Authenticate:**
-1. Open `/plugin` menu in Claude Code
-2. Find **figma MCP** under Installed
-3. Press Enter on "Enter to auth"
-4. Complete OAuth in your browser
+### Verify Authentication
 
-No API tokens needed — the MCP uses browser-based OAuth.
+After setup, call `whoami()` to confirm you're connected and see which Figma account is linked.
 
-See [Claude Code MCP docs](https://code.claude.com/docs/en/mcp) for troubleshooting. Use `whoami()` to verify authentication.
+---
 
 ## URL Parsing
 
@@ -184,6 +228,73 @@ generate_diagram(name, mermaidSyntax)
 ```
 
 Generates FigJam diagrams from Mermaid.js syntax. Supports: flowchart, sequence diagram, state diagram, gantt chart.
+
+---
+
+## 🧩 Reusable Components: Think Before You Build
+
+**This is critical.** Before generating any component, ask yourself:
+
+### The Reusability Checklist
+
+1. **Does this pattern appear in 2+ places?** → Extract it as a shared component
+2. **Could this appear in 2+ places later?** → Design it for reuse from the start
+3. **Is there already a component that does 80% of this?** → Extend it with variants, don't duplicate
+
+### Building Reusable Components from Figma
+
+When you see a Figma component (marked with the ◇ diamond icon):
+
+1. **Check Code Connect first** — `get_code_connect_map` to see if it's already mapped
+2. **Extract ALL variants** — Figma component sets define variants (size, state, type). Map every variant to props:
+   ```tsx
+   // Figma variants: Size=sm|md|lg, State=default|hover|active|disabled, Type=primary|secondary|ghost
+   interface ButtonProps {
+     size?: 'sm' | 'md' | 'lg';
+     variant?: 'primary' | 'secondary' | 'ghost';
+     disabled?: boolean;
+     children: React.ReactNode;
+   }
+   ```
+3. **Use design tokens exclusively** — every color, spacing, border-radius, shadow from the token system
+4. **Map it back** — after implementation, use `add_code_connect_map` so future generations reuse your component
+
+### Responsive Component Design
+
+**Every reusable component must work across all screen sizes.** Don't build a component for desktop and then retrofit mobile.
+
+| Component Type | Mobile Strategy | Tablet Strategy | Desktop |
+|---|---|---|---|
+| Card | Full width, stacked | 2-col grid | 3-4 col grid |
+| Navigation | Hamburger + drawer | Collapsed sidebar | Full nav bar |
+| Data table | Card list or scroll | Condensed columns | Full table |
+| Modal/Dialog | Full screen sheet | Centered, 80% width | Centered, max-width |
+| Form | Single column | 2 columns | 2-3 columns |
+| Tabs | Scrollable horizontal | Standard tabs | Standard tabs |
+
+### The "Two Screens" Rule
+
+When you implement a component, always think: **"Where else in this app could this render?"**
+
+- A `<UserCard>` might appear in a list, a sidebar, a modal, and a search result
+- A `<PricingTable>` might appear on landing page AND in settings
+- A `<StatusBadge>` might appear in tables, cards, headers, and notifications
+
+Design for ALL those contexts. Use composition over configuration:
+
+```tsx
+// ❌ Bad: One mega-component with flags for every context
+<UserCard showAvatar showBio showActions inSidebar={true} />
+
+// ✅ Good: Composable pieces
+<UserCard>
+  <UserCard.Avatar size="sm" />
+  <UserCard.Name />
+  <UserCard.Actions>
+    <Button size="sm">Follow</Button>
+  </UserCard.Actions>
+</UserCard>
+```
 
 ---
 

--- a/plugins/specweave-frontend/skills/frontend/SKILL.md
+++ b/plugins/specweave-frontend/skills/frontend/SKILL.md
@@ -562,6 +562,8 @@ export function formatDate(date: string | Date | null | undefined): string {
 
 For Figma design-to-code workflows, design tokens, and Code Connect, use the **figma** skill (`/sw-frontend:figma`).
 
+> 💡 **Tip**: If you're building UI components and have designs in Figma, strongly consider setting up the [official Figma MCP server](https://www.figma.com/blog/introducing-claude-code-to-figma/) (`claude mcp add figma -- npx -y figma-developer-mcp --stdio`). It lets the agent read your actual designs, extract tokens, and generate pixel-accurate responsive components — especially valuable for building reusable component libraries.
+
 ## Tools and Libraries
 
 **React Ecosystem**:


### PR DESCRIPTION
## Summary

Restores and enhances the Figma skill per #1190.

### Changes

**Figma SKILL.md** — major enhancements:
- **Official MCP setup**: Replaced outdated plugin install instructions with the real setup: `claude mcp add figma -- npx -y figma-developer-mcp --stdio` (OAuth-based, no API tokens)
- **When to Recommend section**: Proactively suggests Figma MCP when agent detects UI/design work — without forcing installation
- **Reusable Components section**: Comprehensive guidance including reusability checklist, variant extraction, responsive component matrix, Two Screens rule, and composition patterns
- **Blog reference**: Links to [official Figma blog post](https://www.figma.com/blog/introducing-claude-code-to-figma/)

**Frontend SKILL.md** — added Figma MCP recommendation tip.

Closes #1190