### PR TITLE
fix: resolve 3 specweave-vskill integration issues

### DIFF
--- a/src/cli/commands/migrate-to-vskill.ts
+++ b/src/cli/commands/migrate-to-vskill.ts
@@ -48,27 +48,43 @@ const LOCKFILE_NAME = 'vskill.lock';
 /**
  * Compute a SHA-256 content hash for a plugin directory.
  *
- * Reads all files in the directory (non-recursive, top-level only),
- * sorts them by name for determinism, concatenates their contents,
- * and returns the hex-encoded SHA-256 digest.
+ * Uses the same algorithm as vskill's computeSha(files) for compatibility:
+ * - Sorts files by relative path
+ * - Format: "relativePath\0normalizedContent\n" per file
+ * - Normalizes content: strip BOM, convert CRLF to LF
+ * - Recursively reads all files (not just top-level)
  */
 function computeDirectoryHash(dirPath: string): string {
   const hash = createHash('sha256');
+  const files: { relPath: string; content: string }[] = [];
 
-  try {
-    const entries = readdirSync(dirPath, { withFileTypes: true });
-    const files = entries
-      .filter(e => e.isFile())
-      .map(e => e.name)
-      .sort();
-
-    for (const file of files) {
-      const content = readFileSync(join(dirPath, file), 'utf-8');
-      hash.update(content);
+  function walkDir(dir: string, prefix: string) {
+    try {
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = join(dir, entry.name);
+        const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+        if (entry.isDirectory()) {
+          walkDir(fullPath, relPath);
+        } else if (entry.isFile()) {
+          const content = readFileSync(fullPath, 'utf-8');
+          files.push({ relPath, content });
+        }
+      }
+    } catch {
+      // If we can't read, skip
     }
-  } catch {
-    // If we can't read the directory, return a hash of empty string
-    hash.update('');
+  }
+
+  walkDir(dirPath, '');
+
+  // Sort by path for determinism (matches vskill)
+  files.sort((a, b) => a.relPath.localeCompare(b.relPath));
+
+  for (const file of files) {
+    // Normalize: strip BOM, convert CRLF to LF (matches vskill's normalizeContent)
+    const normalized = file.content.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+    hash.update(`${file.relPath}\0${normalized}\n`);
   }
 
   return hash.digest('hex');
@@ -172,9 +188,9 @@ export function migrateToVskill(opts?: MigrateOptions): MigrationResult {
     skills[plugin.name] = {
       version: '1.0.0',
       sha,
-      tier: 'free',
+      tier: 'VERIFIED',
       installedAt: now,
-      source: 'migration',
+      source: `marketplace:anton-abyzov/specweave#${plugin.name}`,
       marketplace: 'specweave',
       pluginDir: true,
       scope: 'user',

--- a/src/cli/commands/refresh-plugins.ts
+++ b/src/cli/commands/refresh-plugins.ts
@@ -316,11 +316,11 @@ export async function refreshPluginsCommand(options: RefreshPluginsOptions = {})
     }
 
     if (result.success && result.skipped) {
-      log(chalk.green(`  ✓ ${plugin.name}: active`));
+      log(chalk.green(`  ✓ ${plugin.name}: active`) + (plugin.version ? chalk.gray(` (v${plugin.version})`) : ''));
       skipped++;
       installedPluginNames.push(plugin.name);
     } else if (result.success) {
-      log(chalk.green(`  + ${plugin.name}: installed`));
+      log(chalk.green(`  + ${plugin.name}: installed`) + (plugin.version ? chalk.gray(` (v${plugin.version})`) : ''));
       installed++;
       installedPluginNames.push(plugin.name);
     } else {


### PR DESCRIPTION
## Summary

Fixes 3 critical integration issues between specweave and vskill discovered during a cross-repo ecosystem review of the skill versioning and installation flow.

- **SHA hashing mismatch (#1 — CRITICAL):** `computeDirectoryHash` now uses the same algorithm as vskill's `computeSha(files)` — recursive directory walk, `relativePath\0normalizedContent\n` format, BOM stripping, and CRLF normalization. Previously used a flat concatenation without path info or normalization, causing every `vskill update` to incorrectly detect content changes on migrated plugins.
- **Version display in refresh (#9):** Plugin refresh output now shows the plugin version from `marketplace.json` (e.g. `+ sw: installed (v1.2.3)`), giving users visibility into which versions are being installed.
- **Migration tier/source format (#10):** `migrateToVskill` now writes `tier: "VERIFIED"` (valid vskill tier) instead of `"free"`, and uses `source: "marketplace:anton-abyzov/specweave#pluginName"` format instead of `"migration"`. This enables vskill's `parseSource()` to correctly route update fetches for migrated plugins.

## Files changed

| File | Change |
|------|--------|
| `src/cli/commands/migrate-to-vskill.ts` | SHA algorithm fix, tier/source format fix |
| `src/cli/commands/refresh-plugins.ts` | Version display in plugin refresh output |

## Test plan

- [ ] `migrateToVskill()` produces SHA hashes that match `vskill`'s `computeSha()` for the same directory content
- [ ] `vskill update` after migration correctly reports "already up to date" when content hasn't changed
- [ ] Lockfile entries have `source: "marketplace:anton-abyzov/specweave#sw"` format
- [ ] Lockfile entries have `tier: "VERIFIED"` instead of `"free"`
- [ ] `specweave update` shows version numbers next to plugin names during refresh

https://claude.ai/code/session_01RUfe8W1tSkUinPA2C8H8rr