### PR TITLE
Replace retired Claude model id in the translation hooks

### DIFF
--- a/plugins/specweave/lib/hooks/invoke-translator-skill.js
+++ b/plugins/specweave/lib/hooks/invoke-translator-skill.js
@@ -41,7 +41,7 @@ async function performTranslation(prompt, preserved) {
         apiKey
       });
       const message = await anthropic.messages.create({
-        model: "claude-3-5-haiku-20241022",
+        model: "claude-haiku-4-5-20251001",
         max_tokens: 8e3,
         messages: [
           {

--- a/plugins/specweave/lib/hooks/invoke-translator-skill.ts
+++ b/plugins/specweave/lib/hooks/invoke-translator-skill.ts
@@ -117,7 +117,7 @@ async function performTranslation(
       });
 
       const message = await anthropic.messages.create({
-        model: 'claude-3-5-haiku-20241022',
+        model: 'claude-haiku-4-5-20251001',
         max_tokens: 8000,
         messages: [
           {

--- a/plugins/specweave/lib/hooks/translate-file.js
+++ b/plugins/specweave/lib/hooks/translate-file.js
@@ -115,7 +115,7 @@ async function invokeLLMTranslation(prompt, verbose) {
         apiKey
       });
       const message = await anthropic.messages.create({
-        model: "claude-3-5-haiku-20241022",
+        model: "claude-haiku-4-5-20251001",
         max_tokens: 8e3,
         messages: [
           {
@@ -127,7 +127,7 @@ async function invokeLLMTranslation(prompt, verbose) {
       const translatedContent = message.content[0].type === "text" ? message.content[0].text : contentToTranslate;
       if (verbose) {
         console.log(`\u2705 Translation complete via API`);
-        console.log(`   Model: claude-3-5-haiku-20241022`);
+        console.log(`   Model: claude-haiku-4-5-20251001`);
         console.log(`   Input tokens: ${message.usage.input_tokens}`);
         console.log(`   Output tokens: ${message.usage.output_tokens}`);
         console.log(`   Cost: ~$${((message.usage.input_tokens * 0.25 + message.usage.output_tokens * 1.25) / 1e6).toFixed(4)}`);

--- a/plugins/specweave/lib/hooks/translate-file.ts
+++ b/plugins/specweave/lib/hooks/translate-file.ts
@@ -213,7 +213,7 @@ async function invokeLLMTranslation(prompt: string, verbose: boolean): Promise<s
       });
 
       const message = await anthropic.messages.create({
-        model: 'claude-3-5-haiku-20241022',
+        model: 'claude-haiku-4-5-20251001',
         max_tokens: 8000,
         messages: [
           {
@@ -230,7 +230,7 @@ async function invokeLLMTranslation(prompt: string, verbose: boolean): Promise<s
 
       if (verbose) {
         console.log(`✅ Translation complete via API`);
-        console.log(`   Model: claude-3-5-haiku-20241022`);
+        console.log(`   Model: claude-haiku-4-5-20251001`);
         console.log(`   Input tokens: ${message.usage.input_tokens}`);
         console.log(`   Output tokens: ${message.usage.output_tokens}`);
         console.log(`   Cost: ~$${((message.usage.input_tokens * 0.25 + message.usage.output_tokens * 1.25) / 1000000).toFixed(4)}`);


### PR DESCRIPTION
The translation hooks call `claude-3-5-haiku-20241022`. That id was retired on 19 February 2026, and the documented replacement is Claude Haiku 4.5.

The rest of the repo is already current. `src/core/llm/types.ts` maps `haiku` to `claude-haiku-4-5-20251001`, and the pricing registry tests use the same string, so I used that exact form here instead of the bare alias.

| File | Lines |
| --- | --- |
| `plugins/specweave/lib/hooks/translate-file.ts` | 216, 233 |
| `plugins/specweave/lib/hooks/translate-file.js` | 118, 130 |
| `plugins/specweave/lib/hooks/invoke-translator-skill.ts` | 120 |
| `plugins/specweave/lib/hooks/invoke-translator-skill.js` | 44 |

Four of the six are the `model` field passed to `anthropic.messages.create`. The other two are the `console.log` lines that report which model ran, updated so the verbose output stays accurate.

I changed the `.js` files alongside the `.ts` ones. `tsconfig.json` excludes `plugins/**/lib/hooks/**/*.ts`, so `npm run build` does not regenerate them, and leaving one side alone would let the two drift apart.

There is one thing I deliberately left alone. The cost line beside each call multiplies by 0.25 and 1.25 per million tokens, which is Haiku 3.5 pricing. Haiku 4.5 is $1 and $5 per million, the rates already encoded in `tests/unit/pricing-constants.test.ts`. Changing the model id therefore leaves that estimate low by a factor of four. That is a pricing correction rather than an id fix, so I kept it out of this diff, but you may want it. The same figures appear in a comment in `plugins/specweave/lib/vendor/utils/translation.d.ts`.

I also left `src/core/llm/providers/bedrock-provider.ts` untouched, where `claude-3-5-sonnet` appears in a pricing lookup. Retired models still need pricing history, so that string should stay.

Reference: [Model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations)

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am mentioning that up front rather than leaving you to wonder. I have not run the hooks against the API to reproduce a failure, so the claim rests on the published retirement date. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
