### PR TITLE
0876: fix portable hook execution and release 2.0.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "specweave",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SpecWeave - Spec-Driven Development Framework. PM-led planning, intelligent model selection, living documentation, multi-tool support.",
   "owner": {
     "name": "Anton Abyzov",
@@ -12,7 +12,7 @@
       "description": "SpecWeave unified plugin — increment lifecycle (plan, work the ledger, verify, review, complete), cross-tool handoff, GitHub/Jira/ADO sync",
       "source": "./plugins/specweave",
       "category": "development",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "author": {
         "name": "Anton Abyzov",
         "email": "anton.abyzov@gmail.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "specweave",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "SpecWeave - Spec-Driven Development Framework. PM-led planning, intelligent model selection, living documentation, multi-tool support.",
   "owner": {
     "name": "Anton Abyzov",
@@ -12,7 +12,7 @@
       "description": "SpecWeave unified plugin — increment lifecycle (plan, work the ledger, verify, review, complete), cross-tool handoff, GitHub/Jira/ADO sync",
       "source": "./plugins/specweave",
       "category": "development",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "author": {
         "name": "Anton Abyzov",
         "email": "anton.abyzov@gmail.com"

--- a/.github/workflows/hooks-crossplatform.yml
+++ b/.github/workflows/hooks-crossplatform.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Validate hooks.json is exec-form node with timeouts in seconds
+      - name: Validate portable hook commands and timeouts
         run: >-
           node -e "const h=require('./plugins/specweave/hooks/hooks.json').hooks;
           const bad=[];
           for (const [ev,groups] of Object.entries(h)) for (const g of groups) for (const x of g.hooks) {
-            if (x.command!=='node'||!Array.isArray(x.args)||!x.args[0].includes('run.mjs')) bad.push(ev+': not exec-form node');
+            if (!x.command?.startsWith('node ')||!x.command.includes('/hooks/run.mjs')||x.args) bad.push(ev+': invalid command string');
             if (typeof x.timeout!=='number'||x.timeout>60) bad.push(ev+': timeout must be <=60 s');
           }
           if (bad.length) { console.error(bad.join('\n')); process.exit(1); }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [2.0.0] - 2026-09-02
 
+## [2.0.2] - 2026-09-06
+
+### Fixed
+- Use quoted hook command strings compatible with Codex instead of ignored argument fields.
+- Enforce hook deadlines in a supervisor process, terminate stalled workers, and preserve streamed UTF-8.
+- Capture handoffs through a private Git index with a shared execution budget, preserving user staging even during interruption.
+
+
 SpecWeave 2.0 keeps the parts of 1.x the evidence showed people used, and deletes the rest. Full narrative: https://spec-weave.com/docs/guides/specweave-2
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [2.0.0] - 2026-09-02
 
-## [2.0.2] - 2026-09-06
+## [2.0.3] - 2026-09-06
 
 ### Fixed
-- Use quoted hook command strings compatible with Codex instead of ignored argument fields.
+- Use quoted hook command strings compatible with Codex instead of ignored argument fields, and validate the same format in doctor.
 - Enforce hook deadlines in a supervisor process, terminate stalled workers, and preserve streamed UTF-8.
 - Capture handoffs through a private Git index with a shared execution budget, preserving user staging even during interruption.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specweave",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specweave",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specweave",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specweave",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specweave",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "100+ domain-expert AI skills — PM, Architect, Frontend, QA, Security and more. Skills learn your team's patterns permanently. Spec-first planning, autonomous execution, multi-agent teams, synced to GitHub/JIRA. Claude Code, Cursor, Copilot & more.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specweave",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "100+ domain-expert AI skills — PM, Architect, Frontend, QA, Security and more. Skills learn your team's patterns permanently. Spec-first planning, autonomous execution, multi-agent teams, synced to GitHub/JIRA. Claude Code, Cursor, Copilot & more.",
   "type": "module",
   "bin": {

--- a/plugins/specweave/.claude-plugin/plugin.json
+++ b/plugins/specweave/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sw",
   "description": "SpecWeave: increment lifecycle for any AI tool. 10 skills (increment, do, done, review, team, handoff, sync, auto, brainstorm, qa), 4 exec-form hooks, and the specweave CLI for everything deterministic.",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "author": {
     "name": "SpecWeave Team",
     "url": "https://spec-weave.com"

--- a/plugins/specweave/.claude-plugin/plugin.json
+++ b/plugins/specweave/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sw",
   "description": "SpecWeave: increment lifecycle for any AI tool. 10 skills (increment, do, done, review, team, handoff, sync, auto, brainstorm, qa), 4 exec-form hooks, and the specweave CLI for everything deterministic.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": {
     "name": "SpecWeave Team",
     "url": "https://spec-weave.com"

--- a/plugins/specweave/hooks/hooks.json
+++ b/plugins/specweave/hooks/hooks.json
@@ -1,13 +1,12 @@
 {
-  "description": "SpecWeave 2.0 hooks: session context, status-completion guard, auto-loop driver, compaction handoff. Exec-form node launcher (no shell), Windows-safe.",
+  "description": "SpecWeave hooks: portable command strings and bounded worker execution.",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs", "session-start"],
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs\" session-start",
             "timeout": 10
           }
         ]
@@ -19,8 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs", "pre-tool-use"],
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs\" pre-tool-use",
             "timeout": 10
           }
         ]
@@ -31,8 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs", "stop"],
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs\" stop",
             "timeout": 30
           }
         ]
@@ -43,8 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs", "pre-compact"],
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs\" pre-compact",
             "timeout": 10
           }
         ]

--- a/plugins/specweave/hooks/run-worker.mjs
+++ b/plugins/specweave/hooks/run-worker.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * SpecWeave hook launcher (zero-dependency, cross-platform).
+ *
+ * Invoked by Claude Code in exec form (no shell):
+ *   node ${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs <event>
+ *
+ * Contract:
+ *   - reads the hook JSON from stdin (5 s cap), normalizes backslashes in
+ *     tool_input.file_path, locates the installed `specweave` CLI, imports its
+ *     built hook router and prints exactly ONE JSON object;
+ *   - always exits 0; on ANY failure prints `{}` (pass) — except SessionStart,
+ *     which prints an additionalContext line telling the user the CLI is missing.
+ *
+ * CLI root resolution order:
+ *   1. $SPECWEAVE_HOME
+ *   2. <plugin root>/../..  (plugin shipped inside the npm package / repo checkout)
+ *   3. require.resolve('specweave/package.json') from $CLAUDE_PROJECT_DIR / cwd
+ *   4. `npm root -g` (result cached in a per-user private file under ~/.specweave)
+ *
+ * Fast path: PreToolUse for a file outside `.specweave/increments/` prints `{}`
+ * without loading the CLI at all (the guards only concern increment files).
+ */
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const EVENTS = new Set(['session-start', 'pre-tool-use', 'stop', 'pre-compact']);
+const STDIN_CAP_MS = 5000;
+const ROUTER_REL = path.join('dist', 'src', 'core', 'hooks', 'handlers', 'hook-router.js');
+/**
+ * Per-user cache path. NEVER the shared OS temp dir: run.mjs `import()`s the
+ * path it reads back, so a world-writable cache is arbitrary code execution on
+ * every SessionStart/Stop/PreCompact of every session on the machine.
+ */
+const CACHE_DIR = safeHomeDir() ? path.join(safeHomeDir(), '.specweave') : null;
+const CACHE_FILE = CACHE_DIR ? path.join(CACHE_DIR, 'hook-cli-root') : null;
+
+function safeHomeDir() {
+  try {
+    const home = homedir();
+    return home && path.isAbsolute(home) ? home : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True only for a regular file (not a symlink) owned by the current user. */
+function isPrivateOwnedFile(file) {
+  try {
+    const st = lstatSync(file);
+    if (!st.isFile()) return false;
+    const uid = typeof process.getuid === 'function' ? process.getuid() : null;
+    return uid === null || st.uid === uid;
+  } catch {
+    return false;
+  }
+}
+
+const event = process.argv[2] ?? '';
+
+function inactiveOutput() {
+  if (event === 'session-start') {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext:
+          'SpecWeave hooks inactive: specweave CLI not found (npm i -g specweave)',
+      },
+    };
+  }
+  return {};
+}
+
+let printed = false;
+function emit(obj) {
+  if (printed) return;
+  printed = true;
+  let text = '{}';
+  try {
+    text = JSON.stringify(obj && typeof obj === 'object' ? obj : {});
+  } catch {
+    text = '{}';
+  }
+  process.stdout.write(text + '\n', () => process.exit(0));
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    };
+    const timer = setTimeout(finish, STDIN_CAP_MS);
+    if (timer.unref) timer.unref();
+    try {
+      process.stdin.on('data', (c) => chunks.push(c));
+      process.stdin.on('end', finish);
+      process.stdin.on('error', finish);
+      process.stdin.on('close', finish);
+      if (process.stdin.readableEnded) finish();
+    } catch {
+      finish();
+    }
+  });
+}
+
+/** Returns { raw, skip } — `skip` when the event cannot possibly need the CLI. */
+function normalizeInput(raw) {
+  try {
+    const input = JSON.parse(raw);
+    if (input && typeof input === 'object') {
+      const ti = input.tool_input;
+      let filePath = '';
+      if (ti && typeof ti === 'object' && typeof ti.file_path === 'string') {
+        ti.file_path = ti.file_path.replace(/\\/g, '/');
+        filePath = ti.file_path;
+      }
+      if (typeof input.cwd === 'string') input.cwd = input.cwd.replace(/\\/g, '/');
+      const skip = event === 'pre-tool-use' && !filePath.includes('.specweave/increments/');
+      return { raw: JSON.stringify(input), skip };
+    }
+  } catch {
+    // fall through — the router tolerates a non-JSON payload
+  }
+  return { raw, skip: false };
+}
+
+function isCliRoot(dir) {
+  if (!dir) return false;
+  try {
+    const pkg = path.join(dir, 'package.json');
+    if (!existsSync(pkg) || !existsSync(path.join(dir, ROUTER_REL))) return false;
+    return JSON.parse(readFileSync(pkg, 'utf8')).name === 'specweave';
+  } catch {
+    return false;
+  }
+}
+
+function pluginRoot() {
+  if (process.env.CLAUDE_PLUGIN_ROOT) return path.resolve(process.env.CLAUDE_PLUGIN_ROOT);
+  return path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+}
+
+function fromCache() {
+  if (!CACHE_FILE || !isPrivateOwnedFile(CACHE_FILE)) return null;
+  try {
+    const cached = readFileSync(CACHE_FILE, 'utf8').trim();
+    return isCliRoot(cached) ? cached : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(dir) {
+  if (!CACHE_DIR || !CACHE_FILE) return;
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 });
+    // Drop whatever is there (possibly a planted symlink) before writing.
+    rmSync(CACHE_FILE, { force: true });
+    writeFileSync(CACHE_FILE, dir, { flag: 'wx', mode: 0o600 });
+  } catch {
+    // cache is best-effort
+  }
+}
+
+function fromNpmGlobal() {
+  try {
+    const res = spawnSync('npm root -g', { shell: true, encoding: 'utf8', timeout: 4000 });
+    const root = (res.stdout || '').trim().split(/\r?\n/).pop();
+    if (!root) return null;
+    const dir = path.join(root, 'specweave');
+    if (!isCliRoot(dir)) return null;
+    writeCache(dir);
+    return dir;
+  } catch {
+    return null;
+  }
+}
+
+function resolveCliRoot() {
+  const candidates = [
+    () => process.env.SPECWEAVE_HOME,
+    () => path.resolve(pluginRoot(), '..', '..'),
+    ...[process.env.CLAUDE_PROJECT_DIR, process.cwd()].filter(Boolean).flatMap((dir) => [
+      () => path.dirname(createRequire(path.join(dir, 'package.json')).resolve('specweave/package.json')),
+      () => path.join(dir, 'node_modules', 'specweave'),
+    ]),
+    fromCache,
+    fromNpmGlobal,
+  ];
+  for (const candidate of candidates) {
+    try {
+      const dir = candidate();
+      if (isCliRoot(dir)) return dir;
+    } catch {
+      // try the next strategy
+    }
+  }
+  return null;
+}
+
+async function main() {
+  if (!EVENTS.has(event)) {
+    await readStdin();
+    return emit({});
+  }
+  const { raw, skip } = normalizeInput(await readStdin());
+  if (skip) return emit({});
+  const cliRoot = resolveCliRoot();
+  if (!cliRoot) return emit(inactiveOutput());
+  try {
+    const mod = await import(pathToFileURL(path.join(cliRoot, ROUTER_REL)).href);
+    const result = await mod.hookRouter(event, raw);
+    return emit(result);
+  } catch {
+    return emit(inactiveOutput());
+  }
+}
+
+process.on('uncaughtException', () => emit(inactiveOutput()));
+process.on('unhandledRejection', () => emit(inactiveOutput()));
+main().catch(() => emit(inactiveOutput()));

--- a/plugins/specweave/hooks/run.mjs
+++ b/plugins/specweave/hooks/run.mjs
@@ -1,229 +1,72 @@
 #!/usr/bin/env node
-/**
- * SpecWeave hook launcher (zero-dependency, cross-platform).
- *
- * Invoked by Claude Code in exec form (no shell):
- *   node ${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs <event>
- *
- * Contract:
- *   - reads the hook JSON from stdin (5 s cap), normalizes backslashes in
- *     tool_input.file_path, locates the installed `specweave` CLI, imports its
- *     built hook router and prints exactly ONE JSON object;
- *   - always exits 0; on ANY failure prints `{}` (pass) — except SessionStart,
- *     which prints an additionalContext line telling the user the CLI is missing.
- *
- * CLI root resolution order:
- *   1. $SPECWEAVE_HOME
- *   2. <plugin root>/../..  (plugin shipped inside the npm package / repo checkout)
- *   3. require.resolve('specweave/package.json') from $CLAUDE_PROJECT_DIR / cwd
- *   4. `npm root -g` (result cached in a per-user private file under ~/.specweave)
- *
- * Fast path: PreToolUse for a file outside `.specweave/increments/` prints `{}`
- * without loading the CLI at all (the guards only concern increment files).
- */
-import { createRequire } from 'node:module';
-import { spawnSync } from 'node:child_process';
-import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+// SpecWeave hook supervisor: parent deadline remains live while the worker blocks in Git.
+import { spawn, spawnSync } from 'node:child_process';
+import { appendFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-
-const EVENTS = new Set(['session-start', 'pre-tool-use', 'stop', 'pre-compact']);
-const STDIN_CAP_MS = 5000;
-const ROUTER_REL = path.join('dist', 'src', 'core', 'hooks', 'handlers', 'hook-router.js');
-/**
- * Per-user cache path. NEVER the shared OS temp dir: run.mjs `import()`s the
- * path it reads back, so a world-writable cache is arbitrary code execution on
- * every SessionStart/Stop/PreCompact of every session on the machine.
- */
-const CACHE_DIR = safeHomeDir() ? path.join(safeHomeDir(), '.specweave') : null;
-const CACHE_FILE = CACHE_DIR ? path.join(CACHE_DIR, 'hook-cli-root') : null;
-
-function safeHomeDir() {
+import { fileURLToPath } from 'node:url';
+const event = process.argv[2];
+const worker = path.join(path.dirname(fileURLToPath(import.meta.url)), 'run-worker.mjs');
+const budget = event === 'stop' ? 25000 : 7500;
+let child, finished = false, input = '', output = '', size = 0;
+const started = Date.now();
+function record(reason) {
   try {
-    const home = homedir();
-    return home && path.isAbsolute(home) ? home : null;
-  } catch {
-    return null;
+    const dir = path.join(homedir(), '.specweave', 'logs');
+    mkdirSync(dir, {recursive:true, mode:0o700});
+    appendFileSync(path.join(dir, 'hook-health.jsonl'), JSON.stringify({at:new Date().toISOString(),event,reason,elapsedMs:Date.now()-started})+'\n', {mode:0o600});
+  } catch {}
+}
+function killWorker() {
+  if (!child?.pid) return;
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], {timeout:1000, windowsHide:true, stdio:'ignore'});
+  } else {
+    try { process.kill(-child.pid, 'SIGKILL'); } catch { try {child.kill('SIGKILL');} catch {} }
   }
 }
-
-/** True only for a regular file (not a symlink) owned by the current user. */
-function isPrivateOwnedFile(file) {
-  try {
-    const st = lstatSync(file);
-    if (!st.isFile()) return false;
-    const uid = typeof process.getuid === 'function' ? process.getuid() : null;
-    return uid === null || st.uid === uid;
-  } catch {
-    return false;
-  }
+function finish(result = {}, reason) {
+  if (finished) return;
+  finished = true;
+  clearTimeout(deadline);
+  killWorker();
+  if (reason) record(reason);
+  process.stdout.write(JSON.stringify(result)+'\n',()=>process.exit(0));
 }
-
-const event = process.argv[2] ?? '';
-
-function inactiveOutput() {
-  if (event === 'session-start') {
-    return {
-      hookSpecificOutput: {
-        hookEventName: 'SessionStart',
-        additionalContext:
-          'SpecWeave hooks inactive: specweave CLI not found (npm i -g specweave)',
-      },
-    };
-  }
-  return {};
-}
-
-let printed = false;
-function emit(obj) {
-  if (printed) return;
-  printed = true;
-  let text = '{}';
-  try {
-    text = JSON.stringify(obj && typeof obj === 'object' ? obj : {});
-  } catch {
-    text = '{}';
-  }
-  process.stdout.write(text + '\n', () => process.exit(0));
-}
-
-function readStdin() {
-  return new Promise((resolve) => {
-    const chunks = [];
-    let done = false;
-    const finish = () => {
-      if (done) return;
-      done = true;
-      resolve(Buffer.concat(chunks).toString('utf8'));
-    };
-    const timer = setTimeout(finish, STDIN_CAP_MS);
-    if (timer.unref) timer.unref();
-    try {
-      process.stdin.on('data', (c) => chunks.push(c));
-      process.stdin.on('end', finish);
-      process.stdin.on('error', finish);
-      process.stdin.on('close', finish);
-      if (process.stdin.readableEnded) finish();
-    } catch {
-      finish();
-    }
+const deadline = setTimeout(()=>finish({},'deadline_exceeded'),budget);
+process.on('SIGTERM',()=>finish({},'terminated'));
+process.on('SIGINT',()=>finish({},'interrupted'));
+process.on('uncaughtException',()=>finish({},'adapter_error'));
+process.stdin.setEncoding('utf8');
+process.stdin.on('data',chunk=>{
+  size += Buffer.byteLength(chunk, 'utf8');
+  if(size>1024*1024) return finish({},'input_limit');
+  input+=chunk;
+});
+process.stdin.on('error',()=>finish({},'stdin_error'));
+process.stdin.on('end',()=>{
+  let data;
+  try {data=JSON.parse(input);if(!data || typeof data!=='object'||Array.isArray(data))throw Error();}
+  catch {return finish({},'invalid_input');}
+  if(!['session-start','pre-tool-use','pre-compact','stop'].includes(event))return finish({});
+  const env={...process.env};
+  child=spawn(process.execPath,[worker,event],{env,detached:process.platform !== 'win32',stdio:['pipe','pipe','pipe']});
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data',chunk=>{
+    output+=chunk;
+    if(output.length>1024*1024)finish({},'output_limit');
   });
-}
-
-/** Returns { raw, skip } — `skip` when the event cannot possibly need the CLI. */
-function normalizeInput(raw) {
-  try {
-    const input = JSON.parse(raw);
-    if (input && typeof input === 'object') {
-      const ti = input.tool_input;
-      let filePath = '';
-      if (ti && typeof ti === 'object' && typeof ti.file_path === 'string') {
-        ti.file_path = ti.file_path.replace(/\\/g, '/');
-        filePath = ti.file_path;
-      }
-      if (typeof input.cwd === 'string') input.cwd = input.cwd.replace(/\\/g, '/');
-      const skip = event === 'pre-tool-use' && !filePath.includes('.specweave/increments/');
-      return { raw: JSON.stringify(input), skip };
-    }
-  } catch {
-    // fall through — the router tolerates a non-JSON payload
-  }
-  return { raw, skip: false };
-}
-
-function isCliRoot(dir) {
-  if (!dir) return false;
-  try {
-    const pkg = path.join(dir, 'package.json');
-    if (!existsSync(pkg) || !existsSync(path.join(dir, ROUTER_REL))) return false;
-    return JSON.parse(readFileSync(pkg, 'utf8')).name === 'specweave';
-  } catch {
-    return false;
-  }
-}
-
-function pluginRoot() {
-  if (process.env.CLAUDE_PLUGIN_ROOT) return path.resolve(process.env.CLAUDE_PLUGIN_ROOT);
-  return path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-}
-
-function fromCache() {
-  if (!CACHE_FILE || !isPrivateOwnedFile(CACHE_FILE)) return null;
-  try {
-    const cached = readFileSync(CACHE_FILE, 'utf8').trim();
-    return isCliRoot(cached) ? cached : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeCache(dir) {
-  if (!CACHE_DIR || !CACHE_FILE) return;
-  try {
-    mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 });
-    // Drop whatever is there (possibly a planted symlink) before writing.
-    rmSync(CACHE_FILE, { force: true });
-    writeFileSync(CACHE_FILE, dir, { flag: 'wx', mode: 0o600 });
-  } catch {
-    // cache is best-effort
-  }
-}
-
-function fromNpmGlobal() {
-  try {
-    const res = spawnSync('npm root -g', { shell: true, encoding: 'utf8', timeout: 4000 });
-    const root = (res.stdout || '').trim().split(/\r?\n/).pop();
-    if (!root) return null;
-    const dir = path.join(root, 'specweave');
-    if (!isCliRoot(dir)) return null;
-    writeCache(dir);
-    return dir;
-  } catch {
-    return null;
-  }
-}
-
-function resolveCliRoot() {
-  const candidates = [
-    () => process.env.SPECWEAVE_HOME,
-    () => path.resolve(pluginRoot(), '..', '..'),
-    ...[process.env.CLAUDE_PROJECT_DIR, process.cwd()].filter(Boolean).flatMap((dir) => [
-      () => path.dirname(createRequire(path.join(dir, 'package.json')).resolve('specweave/package.json')),
-      () => path.join(dir, 'node_modules', 'specweave'),
-    ]),
-    fromCache,
-    fromNpmGlobal,
-  ];
-  for (const candidate of candidates) {
+  child.stderr.resume();
+  child.stdin.on('error',()=>{});
+  child.on('error',()=>finish({},'worker_spawn_failed'));
+  child.on('close',code=>{
+    if(finished)return;
+    if(code!==0)return finish({},'worker_failed');
     try {
-      const dir = candidate();
-      if (isCliRoot(dir)) return dir;
-    } catch {
-      // try the next strategy
-    }
-  }
-  return null;
-}
-
-async function main() {
-  if (!EVENTS.has(event)) {
-    await readStdin();
-    return emit({});
-  }
-  const { raw, skip } = normalizeInput(await readStdin());
-  if (skip) return emit({});
-  const cliRoot = resolveCliRoot();
-  if (!cliRoot) return emit(inactiveOutput());
-  try {
-    const mod = await import(pathToFileURL(path.join(cliRoot, ROUTER_REL)).href);
-    const result = await mod.hookRouter(event, raw);
-    return emit(result);
-  } catch {
-    return emit(inactiveOutput());
-  }
-}
-
-process.on('uncaughtException', () => emit(inactiveOutput()));
-process.on('unhandledRejection', () => emit(inactiveOutput()));
-main().catch(() => emit(inactiveOutput()));
+      const result=JSON.parse(output);
+      if(!result||typeof result!=='object'||Array.isArray(result))throw Error();
+      finish(result);
+    } catch {finish({},'invalid_worker_output');}
+  });
+  child.stdin.end(input);
+});

--- a/src/core/doctor/checkers/hooks-checker.ts
+++ b/src/core/doctor/checkers/hooks-checker.ts
@@ -78,7 +78,7 @@ export class HooksChecker implements HealthChecker {
     return { category: this.category, status: calculateOverallStatus(checks), checks };
   }
 
-  /** hooks.json must be exec-form (command + args), node-based, with sane timeouts. */
+  /** hooks.json uses a quoted node command string (Codex ignores separate args). */
   private checkHooksJson(hooksJson: string): CheckResult {
     try {
       const data = JSON.parse(fs.readFileSync(hooksJson, 'utf8')) as {
@@ -88,13 +88,15 @@ export class HooksChecker implements HealthChecker {
       for (const [event, groups] of Object.entries(data.hooks ?? {})) {
         for (const group of groups) {
           for (const h of group.hooks ?? []) {
-            if (h.command !== 'node' || !Array.isArray(h.args)) problems.push(`${event}: not exec-form node`);
+            if (!/^node \"\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/run\.mjs\" [a-z-]+$/.test(h.command ?? '') || h.args !== undefined) {
+              problems.push(`${event}: expected quoted node hook command without separate args`);
+            }
             if (typeof h.timeout === 'number' && h.timeout > 60) problems.push(`${event}: timeout ${h.timeout}s > 60s`);
           }
         }
       }
       return problems.length === 0
-        ? { name: 'hooks.json', status: 'pass', message: 'exec-form node launcher, timeouts <= 60s' }
+        ? { name: 'hooks.json', status: 'pass', message: 'portable node launcher, timeouts <= 60s' }
         : { name: 'hooks.json', status: 'fail', message: problems.join('; ') };
     } catch (err) {
       return { name: 'hooks.json', status: 'fail', message: `unreadable: ${err instanceof Error ? err.message : String(err)}` };

--- a/src/core/session/handoff-git-state.test.ts
+++ b/src/core/session/handoff-git-state.test.ts
@@ -170,3 +170,37 @@ describe('captureGitState', () => {
     expect(state.isGitRepo).toBe(false);
   });
 });
+
+it('preserves index bytes and captures quoted Unicode filenames', () => {
+  const repo = mkTmp('handoff-index-bytes-');
+  const out = path.join(os.tmpdir(), `handoff-index-${Date.now()}.diff`);
+  try {
+    git(repo, 'init', '-q');
+    fs.writeFileSync(path.join(repo, 'tracked'), 'base');
+    git(repo, 'add', 'tracked');
+    const index = path.join(repo, '.git', 'index');
+    const before = fs.readFileSync(index);
+    fs.writeFileSync(path.join(repo, 'é "quoted" file.txt'), 'unique untracked content');
+    captureGitState(repo, out);
+    expect(fs.readFileSync(index)).toEqual(before);
+    expect(fs.readFileSync(out, 'utf8')).toContain('unique untracked content');
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(out, { force: true });
+  }
+});
+
+it.skipIf(process.platform === 'win32')('bounds stalled Git by the total capture budget', () => {
+  const repo = mkTmp('handoff-slow-git-');
+  const oldPath = process.env.PATH;
+  try {
+    fs.writeFileSync(path.join(repo, 'git'), '#!/bin/sh\nexec /bin/sleep 12\n', { mode: 0o755 });
+    process.env.PATH = repo + path.delimiter + oldPath;
+    const start = Date.now();
+    expect(captureGitState(repo, path.join(repo, 'out.diff')).isGitRepo).toBe(false);
+    expect(Date.now() - start).toBeLessThan(4500);
+  } finally {
+    process.env.PATH = oldPath;
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+}, 6000);

--- a/src/core/session/handoff-git-state.ts
+++ b/src/core/session/handoff-git-state.ts
@@ -18,6 +18,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 
 /**
  * Captured git state for the handoff doc.
@@ -37,146 +38,66 @@ export interface GitState {
   hasUncommittedChanges: boolean;
 }
 
-/**
- * Run a git command, returning trimmed stdout or `null` on any failure.
- *
- * Uses execFileSync with an argument array (no shell) so paths and refs are
- * never re-interpreted by a shell.
- */
-function git(repoRoot: string, args: string[]): string | null {
-  try {
-    return execFileSync('git', args, {
-      cwd: repoRoot,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      maxBuffer: 64 * 1024 * 1024, // diffs can be large
-    }).trim();
-  } catch {
-    return null;
-  }
-}
+/** Total Git budget leaves headroom below PreCompact's five-second budget. */
+export const GIT_CAPTURE_BUDGET_MS = 3500;
 
-/**
- * Capture git state for `repoRoot` and dump the full uncommitted diff to
- * `diffOutputPath`.
- *
- * The diff file always contains `git diff HEAD` (working-tree vs last commit)
- * concatenated with `git diff --cached` (staged vs HEAD). When the repo is
- * clean — or before the first commit — the file is written empty so callers can
- * unconditionally link to it.
- *
- * @param repoRoot - Absolute path to the candidate repository root.
- * @param diffOutputPath - Absolute path where the full diff is written.
- * @returns The captured {@link GitState}; all-empty + `isGitRepo:false` when
- *          `repoRoot` is not a git work tree (no throw).
- */
+/** Capture through a private index; an interrupted hook never stages user files. */
 export function captureGitState(repoRoot: string, diffOutputPath: string): GitState {
   const empty: GitState = {
-    isGitRepo: false,
-    branch: '',
-    shortSha: '',
-    statusPorcelain: '',
-    diffStat: '',
-    hasUncommittedChanges: false,
+    isGitRepo: false, branch: '', shortSha: '', statusPorcelain: '',
+    diffStat: '', hasUncommittedChanges: false,
   };
+  const deadline = Date.now() + GIT_CAPTURE_BUDGET_MS;
+  const env = { ...process.env, GIT_OPTIONAL_LOCKS: '0' };
+  function git(args: string[], trim = true): string | null {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return null;
+    try {
+      const result = execFileSync('git', args, {
+        cwd: repoRoot, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+        maxBuffer: 64 * 1024 * 1024, timeout: remaining, killSignal: 'SIGKILL',
+      });
+      return trim ? result.trim() : result;
+    } catch { return null; }
+  }
+  let temporary: string | undefined;
+  try {
+    if (git(['rev-parse', '--is-inside-work-tree']) !== 'true') {
+      safeWriteDiff(diffOutputPath, '');
+      return empty;
+    }
+    const indexPath = git(['rev-parse', '--path-format=absolute', '--git-path', 'index']);
+    if (!indexPath) { safeWriteDiff(diffOutputPath, ''); return empty; }
+    temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'specweave-handoff-index-'));
+    const privateIndex = path.join(temporary, 'index');
+    if (fs.existsSync(indexPath)) fs.copyFileSync(indexPath, privateIndex);
+    Object.assign(env, { GIT_INDEX_FILE: privateIndex });
 
-  const insideWorkTree = git(repoRoot, ['rev-parse', '--is-inside-work-tree']);
-  if (insideWorkTree !== 'true') {
-    // Still write an empty diff file so the doc's link target exists.
+    const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']) ?? '';
+    const shortSha = git(['rev-parse', '--short', 'HEAD']) ?? '';
+    const statusPorcelain = git(['status', '--porcelain']) ?? '';
+    // NUL-delimited paths handle spaces, quotes, Unicode and embedded newlines.
+    const untracked = (git(['ls-files', '--others', '--exclude-standard', '-z'], false) ?? '')
+      .split('\0').filter(Boolean);
+    if (untracked.length) git(['add', '-N', '--', ...untracked]);
+    const hasHead = shortSha !== '';
+    const working = ['diff', '--no-ext-diff', '--no-textconv', ...(hasHead ? ['HEAD'] : [])];
+    const staged = ['diff', '--no-ext-diff', '--no-textconv', '--cached'];
+    const workingDiff = git(working) ?? '';
+    const stagedDiff = (hasHead ? git(staged) : '') ?? '';
+    const workingStat = git([...working, '--stat']) ?? '';
+    const stagedStat = (hasHead ? git([...staged, '--stat']) : '') ?? '';
+    safeWriteDiff(diffOutputPath, [workingDiff, stagedDiff].filter(Boolean).join('\n'));
+    return {
+      isGitRepo: true, branch, shortSha, statusPorcelain,
+      diffStat: [workingStat, stagedStat].filter(Boolean).join('\n'),
+      hasUncommittedChanges: statusPorcelain.length > 0,
+    };
+  } catch {
     safeWriteDiff(diffOutputPath, '');
     return empty;
-  }
-
-  const branch = git(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD']) ?? '';
-  const shortSha = git(repoRoot, ['rev-parse', '--short', 'HEAD']) ?? '';
-  const statusPorcelain = git(repoRoot, ['status', '--porcelain']) ?? '';
-
-  // Intent-to-add every untracked file so `git diff` includes its FULL body,
-  // not just a `??` porcelain line. Without this, brand-new uncommitted files —
-  // the most common in-flight-work case — would be captured as a filename only,
-  // breaking the spec's "exact uncommitted edits" promise (AC-US4-01/02).
-  // `add -N` records intent only (no content staged) but it DOES add an index
-  // entry, so we MUST revert it afterward to leave the user's real index exactly
-  // as we found it — a handoff is a read-only capture and must not silently
-  // change `git status`, `git stash`, or `git commit -a` behavior.
-  const intentAdded = stageIntentToAddUntracked(repoRoot, statusPorcelain);
-
-  // `git diff HEAD` covers working-tree vs HEAD; if there is no HEAD yet
-  // (no commits), fall back to plain `git diff` so brand-new repos still work.
-  const hasHead = shortSha !== '';
-  const workingDiff =
-    (hasHead ? git(repoRoot, ['diff', 'HEAD']) : git(repoRoot, ['diff'])) ?? '';
-  const stagedDiff = (hasHead ? git(repoRoot, ['diff', '--cached']) : '') ?? '';
-
-  const workingStat =
-    (hasHead ? git(repoRoot, ['diff', '--stat', 'HEAD']) : git(repoRoot, ['diff', '--stat'])) ?? '';
-  const stagedStat = (hasHead ? git(repoRoot, ['diff', '--cached', '--stat']) : '') ?? '';
-
-  // Restore the index: drop the intent-to-add entries we created so the user's
-  // staging area is byte-identical to its pre-handoff state.
-  unstageIntentToAdd(repoRoot, hasHead, intentAdded);
-
-  const diffStat = [workingStat, stagedStat].filter(Boolean).join('\n');
-
-  const fullDiff = [workingDiff, stagedDiff].filter(Boolean).join('\n');
-  safeWriteDiff(diffOutputPath, fullDiff);
-
-  const hasUncommittedChanges = statusPorcelain.length > 0;
-
-  return {
-    isGitRepo: true,
-    branch,
-    shortSha,
-    statusPorcelain,
-    diffStat,
-    hasUncommittedChanges,
-  };
-}
-
-/**
- * Intent-to-add every untracked file from a porcelain status so its content
- * shows up in `git diff`. Parses `??`-prefixed porcelain lines and runs a
- * single `git add -N -- <paths...>`. Never throws — a failure here only means
- * untracked bodies are omitted, which must not abort the handoff.
- *
- * `add -N` (intent-to-add) records that a path will be tracked but stages NO
- * content. It DOES create an index entry, so the caller MUST pass the returned
- * paths to {@link unstageIntentToAdd} once the diff has been captured to leave
- * the user's real index untouched.
- *
- * @returns The untracked paths that were intent-to-added (empty if none).
- */
-function stageIntentToAddUntracked(repoRoot: string, statusPorcelain: string): string[] {
-  if (!statusPorcelain) return [];
-  const untracked = statusPorcelain
-    .split('\n')
-    .filter((line) => line.startsWith('??'))
-    // Porcelain format is `XY <path>`; for untracked the path starts at col 3.
-    .map((line) => line.slice(3).trim())
-    .filter(Boolean);
-  if (untracked.length === 0) return [];
-  // `--` guards against any path that looks like a flag.
-  git(repoRoot, ['add', '-N', '--', ...untracked]);
-  return untracked;
-}
-
-/**
- * Revert the intent-to-add entries created by {@link stageIntentToAddUntracked}
- * so the user's index is restored to its pre-handoff state. After this the
- * affected files are untracked (`??`) again, exactly as before the capture.
- *
- * `git reset -- <paths>` clears the index entries when a HEAD exists. Before the
- * first commit there is no HEAD, so `git reset` would fail; `git rm --cached
- * --force -- <paths>` removes the intent entries in that case. Never throws — a
- * failed revert must not abort the handoff (worst case: the index keeps the
- * intent entries, which is the pre-fix behavior).
- */
-function unstageIntentToAdd(repoRoot: string, hasHead: boolean, paths: string[]): void {
-  if (paths.length === 0) return;
-  if (hasHead) {
-    git(repoRoot, ['reset', '--quiet', '--', ...paths]);
-  } else {
-    git(repoRoot, ['rm', '--cached', '--force', '--quiet', '--', ...paths]);
+  } finally {
+    if (temporary) try { fs.rmSync(temporary, { recursive: true, force: true }); } catch { /* best effort */ }
   }
 }
 

--- a/tests/unit/hooks/hook-deadline.test.ts
+++ b/tests/unit/hooks/hook-deadline.test.ts
@@ -1,0 +1,51 @@
+import { it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+it('supervises a synchronously stuck router below the 10-second host timeout', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-deadline-'));
+  try {
+    const handler = path.join(root, 'dist/src/core/hooks/handlers');
+    fs.mkdirSync(handler, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'specweave', type: 'module' }));
+    fs.writeFileSync(path.join(handler, 'hook-router.js'), 'export function hookRouter() { while (true) {} }');
+    const start = Date.now();
+    const result = spawnSync(process.execPath, [path.resolve('plugins/specweave/hooks/run.mjs'), 'session-start'], {
+      input: '{}', encoding: 'utf8', timeout: 9500, env: { ...process.env, SPECWEAVE_HOME: root },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({});
+    expect(Date.now() - start).toBeLessThan(9500);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+}, 12000);
+
+it('preserves UTF-8 when stdin bytes arrive in separate chunks', async () => {
+  const { spawn } = await import('node:child_process');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-unicode-'));
+  try {
+    const handler = path.join(root, 'dist/src/core/hooks/handlers');
+    fs.mkdirSync(handler, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'specweave', type: 'module' }));
+    fs.writeFileSync(path.join(handler, 'hook-router.js'), 'export function hookRouter(event, raw) { return JSON.parse(raw); }');
+    const child = spawn(process.execPath, [path.resolve('plugins/specweave/hooks/run.mjs'), 'session-start'], {
+      env: { ...process.env, SPECWEAVE_HOME: root }, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const bytes = Buffer.from(JSON.stringify({ cwd: '/tmp/é' }));
+    const split = bytes.indexOf(0xc3) + 1;
+    let output = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', c => { output += c; });
+    const done = new Promise<void>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', code => code === 0 ? resolve() : reject(new Error(`exit ${code}`)));
+    });
+    child.stdin.write(bytes.subarray(0, split));
+    await new Promise(resolve => setTimeout(resolve, 100));
+    child.stdin.end(bytes.subarray(split));
+    await done;
+    expect(JSON.parse(output).cwd).toBe('/tmp/é');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/tests/unit/hooks/hook-wiring-parity.test.ts
+++ b/tests/unit/hooks/hook-wiring-parity.test.ts
@@ -4,8 +4,8 @@
  * 1. Every event plugins/specweave/hooks/hooks.json launches via
  *    `node ${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs <event>` is registered in the
  *    router, and vice versa (no silent no-op hooks, no dead handlers).
- * 2. Every hooks.json entry is exec-form (`command: "node"` + `args`), never a
- *    shell string (Windows without Git Bash), and every timeout is <= 60 s
+ * 2. Every hooks.json entry uses a portable command string with a quoted
+ *    launcher path (Codex ignores separate args), and every timeout is <= 60 s
  *    (the unit is SECONDS — `15000` once meant 4.2 h).
  * 3. Invoking the router with a sample payload for each event yields output
  *    that is valid per the Claude Code hook schema for that event.
@@ -36,7 +36,7 @@ function allEntries(): Array<{ event: string; matcher?: string; entry: HookEntry
 
 /** The `<event>` argument each hooks.json entry passes to run.mjs. */
 function launchedEvents(): string[] {
-  return [...new Set(allEntries().map(({ entry }) => entry.args?.[1] ?? ''))].sort();
+  return [...new Set(allEntries().map(({ entry }) => entry.command?.split(' ').at(-1) ?? ''))].sort();
 }
 
 describe('hooks.json ↔ router parity', () => {
@@ -46,15 +46,15 @@ describe('hooks.json ↔ router parity', () => {
     expect(registeredHookEvents()).toEqual([...HOOK_EVENTS].sort());
   });
 
-  it('every entry is exec-form node + run.mjs, no shell, no matcher_content', () => {
+  it('every entry uses a portable command string with quoted launcher', () => {
     const raw = fs.readFileSync(path.resolve(process.cwd(), 'plugins/specweave/hooks/hooks.json'), 'utf-8');
     expect(raw).not.toContain('bash');
     expect(raw).not.toContain('matcher_content');
     for (const { event, entry } of allEntries()) {
       expect(entry.type, event).toBe('command');
-      expect(entry.command, event).toBe('node');
-      expect(entry.args?.[0], event).toBe('${CLAUDE_PLUGIN_ROOT}/hooks/run.mjs');
-      expect(HOOK_EVENTS, event).toContain(entry.args?.[1]);
+      expect(entry.command, event).toMatch(/^node \"\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/run\.mjs\" [a-z-]+$/);
+      expect(entry.args, event).toBeUndefined();
+      expect(HOOK_EVENTS, event).toContain(entry.command?.split(' ').at(-1));
     }
   });
 


### PR DESCRIPTION
Codex ignores separate hook `args`, and synchronous Git inside PreCompact prevents its timeout timer from firing. Hooks now use quoted command strings and a separate supervisor that terminates stalled workers before the host deadline. Handoff capture uses a private Git index and a shared Git execution budget, preserving user staging during interruption.

Validation: 155 affected tests pass (including doctor); 145 focused coverage tests pass; changed Git capture reaches 95% line, 78.37% branch coverage. Build, hook smoke, version alignment and npm tarball preflight pass. Independent review cleared after a UTF-8 fragmentation fix. Four external-tool-closure tests also fail unchanged on origin/develop. Patch version 2.0.3 avoids including the local unpublished 2.0.1 cleanup commit.

macOS, Ubuntu and Windows hook runners passed. Broader suite is not fully green; four tracker failures reproduce on baseline, and worktree/live-service fixture failures remain outside this patch. The related doctor format failure is fixed and independently retested. The 2.0.2 release run was cancelled before its publish step.
